### PR TITLE
🛠[FIX] : "gradle 롬복 추가설정"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	annotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/test/java/softee5/demo/AtchaApplicationTests.java
+++ b/src/test/java/softee5/demo/AtchaApplicationTests.java
@@ -3,7 +3,7 @@ package softee5.demo;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = AtchaApplicationTests.class)
 class AtchaApplicationTests {
 
 	@Test


### PR DESCRIPTION
gradle로 빌드했을 때 롬복 오류났던 이유가 gradle버전이 올라가면서 추가 설정을 해야 한다고 하더라구요.
추가 설정부분 넣었습니다.